### PR TITLE
Fix raft loading bug

### DIFF
--- a/StrandedWideMod_Harmony/Main.0.cs
+++ b/StrandedWideMod_Harmony/Main.0.cs
@@ -128,10 +128,10 @@ namespace StrandedWideMod_Harmony
 
                 ReadConfig();
 
-                Main._zoneLoadDistance = IslandSize - 6;
-                Debug.Log("Stranded Wide (Harmony edition) : Load _zoneLoadDistance = " + _zoneLoadDistance);
-                Main._zoneUnloadDistance = _zoneLoadDistance - 10;
+                Main._zoneUnloadDistance = IslandSize - 6 * IslandSizeRatio;
                 Debug.Log("Stranded Wide (Harmony edition) : Load _zoneUnloadDistance = " + _zoneUnloadDistance);
+                Main._zoneLoadDistance = IslandSize - 16 * IslandSizeRatio;
+                Debug.Log("Stranded Wide (Harmony edition) : Load _zoneLoadDistance = " + _zoneLoadDistance);
                 Main._saveBoundsRadius = IslandSize - 101 * IslandSizeRatio;
                 Debug.Log("Stranded Wide (Harmony edition) : Load _saveBoundsRadius = " + _saveBoundsRadius);
 

--- a/StrandedWideMod_Harmony/Main.0.cs
+++ b/StrandedWideMod_Harmony/Main.0.cs
@@ -132,6 +132,8 @@ namespace StrandedWideMod_Harmony
                 Debug.Log("Stranded Wide (Harmony edition) : Load _zoneLoadDistance = " + _zoneLoadDistance);
                 Main._zoneUnloadDistance = _zoneLoadDistance - 10;
                 Debug.Log("Stranded Wide (Harmony edition) : Load _zoneUnloadDistance = " + _zoneUnloadDistance);
+                Main._saveBoundsRadius = IslandSize - 101 * IslandSizeRatio;
+                Debug.Log("Stranded Wide (Harmony edition) : Load _saveBoundsRadius = " + _saveBoundsRadius);
 
                 Debug.Log(modName + " Successfully started. ");
 

--- a/StrandedWideMod_Harmony/Main.1_StrandedWorld.cs
+++ b/StrandedWideMod_Harmony/Main.1_StrandedWorld.cs
@@ -25,10 +25,10 @@ namespace StrandedWideMod_Harmony
                 {
                     CustomLogger.Log("Stranded Wide (Harmony edition) : LoadWorld from StrandedWorld");
 
-                    Main._zoneLoadDistance = IslandSize - 6;
-                    CustomLogger.Log("Stranded Wide (Harmony edition) : LoadWorld _zoneLoadDistance = " + _zoneLoadDistance);
-                    Main._zoneUnloadDistance = _zoneLoadDistance - 10;
+                    Main._zoneUnloadDistance = IslandSize - 6 * IslandSizeRatio;
                     CustomLogger.Log("Stranded Wide (Harmony edition) : LoadWorld _zoneUnloadDistance = " + _zoneUnloadDistance);
+                    Main._zoneLoadDistance = IslandSize - 16 * IslandSizeRatio;
+                    CustomLogger.Log("Stranded Wide (Harmony edition) : LoadWorld _zoneLoadDistance = " + _zoneLoadDistance);
                     Main._saveBoundsRadius = IslandSize - 101 * IslandSizeRatio;
                     CustomLogger.Log("Stranded Wide (Harmony edition) : LoadWorld _saveBoundsRadius = " + _saveBoundsRadius);
 

--- a/StrandedWideMod_Harmony/Main.1_StrandedWorld.cs
+++ b/StrandedWideMod_Harmony/Main.1_StrandedWorld.cs
@@ -29,6 +29,9 @@ namespace StrandedWideMod_Harmony
                     CustomLogger.Log("Stranded Wide (Harmony edition) : LoadWorld _zoneLoadDistance = " + _zoneLoadDistance);
                     Main._zoneUnloadDistance = _zoneLoadDistance - 10;
                     CustomLogger.Log("Stranded Wide (Harmony edition) : LoadWorld _zoneUnloadDistance = " + _zoneUnloadDistance);
+                    Main._saveBoundsRadius = IslandSize - 101 * IslandSizeRatio;
+                    CustomLogger.Log("Stranded Wide (Harmony edition) : LoadWorld _saveBoundsRadius = " + _saveBoundsRadius);
+
                     Beam.Terrain.LoadingResult loadingResult = World.LoadWorld();
                     if (loadingResult.Succeeded)
                     {

--- a/StrandedWideMod_Harmony/Main.1_StrandedWorld_IslandsCount.cs
+++ b/StrandedWideMod_Harmony/Main.1_StrandedWorld_IslandsCount.cs
@@ -274,15 +274,10 @@ namespace StrandedWideMod_Harmony
                         mi_PollImposters.Invoke(__instance, new object[] { zone });
                         //__instance.PollZone(zone);
                         
-                        // patch 1.0.35 -> buggy
-                        //if (!(bool)mi_PollUnload.Invoke(__instance, new object[] { zone }))
-                        //{
-                        //    mi_PollLoad.Invoke(__instance, new object[] { zone });
-                        //}
-
-                        // raft bug fix
-                        mi_PollUnload.Invoke(__instance, new object[] { zone });
-                        mi_PollLoad.Invoke(__instance, new object[] { zone });
+                        if (!(bool)mi_PollUnload.Invoke(__instance, new object[] { zone }))
+                        {
+                            mi_PollLoad.Invoke(__instance, new object[] { zone });
+                        }
                     }
 
                     // skip original method

--- a/StrandedWideMod_Harmony/Main.5_World_IslandsCount.cs
+++ b/StrandedWideMod_Harmony/Main.5_World_IslandsCount.cs
@@ -131,6 +131,8 @@ namespace StrandedWideMod_Harmony
                     CustomLogger.Log("Stranded Wide (Harmony edition) : CreateWorld _zoneLoadDistance = " + _zoneLoadDistance);
                     Main._zoneUnloadDistance = _zoneLoadDistance - 10;
                     CustomLogger.Log("Stranded Wide (Harmony edition) : CreateWorld _zoneUnloadDistance = " + _zoneUnloadDistance);
+                    Main._saveBoundsRadius = IslandSize - 101 * IslandSizeRatio;
+                    CustomLogger.Log("Stranded Wide (Harmony edition) : CreateWorld _saveBoundsRadius = " + _saveBoundsRadius);
 
 #warning create world async ?
 

--- a/StrandedWideMod_Harmony/Main.5_World_IslandsCount.cs
+++ b/StrandedWideMod_Harmony/Main.5_World_IslandsCount.cs
@@ -127,10 +127,10 @@ namespace StrandedWideMod_Harmony
                     // persist values
                     WriteConfig();
 
-                    Main._zoneLoadDistance = IslandSize - 6;
-                    CustomLogger.Log("Stranded Wide (Harmony edition) : CreateWorld _zoneLoadDistance = " + _zoneLoadDistance);
-                    Main._zoneUnloadDistance = _zoneLoadDistance - 10;
+                    Main._zoneUnloadDistance = IslandSize - 6 * IslandSizeRatio;
                     CustomLogger.Log("Stranded Wide (Harmony edition) : CreateWorld _zoneUnloadDistance = " + _zoneUnloadDistance);
+                    Main._zoneLoadDistance = IslandSize - 16 * IslandSizeRatio;
+                    CustomLogger.Log("Stranded Wide (Harmony edition) : CreateWorld _zoneLoadDistance = " + _zoneLoadDistance);
                     Main._saveBoundsRadius = IslandSize - 101 * IslandSizeRatio;
                     CustomLogger.Log("Stranded Wide (Harmony edition) : CreateWorld _saveBoundsRadius = " + _saveBoundsRadius);
 

--- a/StrandedWideMod_Harmony/StrandedWideMod_Harmony.csproj
+++ b/StrandedWideMod_Harmony/StrandedWideMod_Harmony.csproj
@@ -34,36 +34,45 @@
   <ItemGroup>
     <Reference Include="0Harmony">
       <HintPath>0Harmony.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>Assembly-CSharp-firstpass.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="bolt">
       <HintPath>bolt.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="bolt.user">
       <HintPath>bolt.user.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Rewired_Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>Rewired_Core.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Sirenix.Serialization, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>Sirenix.Serialization.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Sirenix.Serialization.Config, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>Sirenix.Serialization.Config.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Sirenix.Utilities, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>Sirenix.Utilities.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -74,44 +83,57 @@
     <Reference Include="System.Xml" />
     <Reference Include="Unity.TextMeshPro">
       <HintPath>Unity.TextMeshPro.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>UnityEngine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
       <HintPath>UnityEngine.ImageConversionModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
       <HintPath>UnityEngine.IMGUIModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>UnityEngine.PhysicsModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TerrainModule">
       <HintPath>UnityEngine.TerrainModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextCoreFontEngineModule">
       <HintPath>UnityEngine.TextCoreFontEngineModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextCoreTextEngineModule">
       <HintPath>UnityEngine.TextCoreTextEngineModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
       <HintPath>UnityEngine.TextRenderingModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>UnityEngine.UI.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>UnityEngine.UIModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityModManager">
       <HintPath>UnityModManager.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixed raft loading bug when approaching island unloading area.

Changes:

- Uncomment old polling code
- Switch zoneLoadingDistance and zoneUnloadingDistance calculations
- Add saveBoundsRadius calculation to Load, CreateWorld, LoadWorld
- Disable copying referenced dll files to output